### PR TITLE
[doc/typo] Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Available options:
 ## install
 
 ```
-$ cabal install
+$ cabal install hpdft
 ```


### PR DESCRIPTION
Fixed missing string (name of the package installed) in the document.

(Thank you for developing such a great tool!)