### PR TITLE
Fixed compilation with GHC 9.6.2

### DIFF
--- a/hpdft.cabal
+++ b/hpdft.cabal
@@ -43,7 +43,6 @@ library
                      , memory >= 0.14.5
                      , optparse-applicative
                      , parsec >=3.0 && <3.2
-                     , regex-compat-tdfa >= 0.95.1.4
                      , semigroups
                      , text >=0.11
                      , utf8-string >=0.3
@@ -63,8 +62,7 @@ executable hpdft
                      , memory >= 0.14.5
                      , optparse-applicative
                      , regex-base >= 0.94.0.2
-                     , regex-compat-tdfa >= 0.95.1.4
-                     , regex-compat-tdfa >= 0.95.1.4
+                     , regex-tdfa >= 0.95.1.4
                      , semigroups
                      , text >=0.11
                      , utf8-string >=0.3

--- a/hpdft.hs
+++ b/hpdft.hs
@@ -24,7 +24,9 @@ import Data.Maybe (fromMaybe)
 import Options.Applicative
 import Data.Semigroup ((<>))
 
-import "regex-compat-tdfa" Text.Regex as R
+import Text.Regex.Base.RegexLike ( makeRegex )
+import Text.Regex.TDFA.String    ( regexec )
+
 import Options.Applicative (strOption)
 import Control.Monad (when)
 import PDF.Definition (Obj(PdfStream))
@@ -288,8 +290,10 @@ grepPDF filename re = do
 
     grepByLine :: String -> PDFStream -> String
     grepByLine re txt =
-      case matchRegexAll (mkRegex re) $ TL.unpack $ TL.decodeUtf8 txt of
-        Just (b, m, a, _) -> (b <> (highlight m) <> a)
-        Nothing -> ""
+      case regexec (makeRegex re) $ TL.unpack $ TL.decodeUtf8 txt of
+        Left _  -> ""
+        Right m -> case m of
+         Just (b, m, a, _) -> (b <> (highlight m) <> a)
+         Nothing           -> ""
 
     highlight m = "\ESC[31m" <> m <> "\ESC[0m"


### PR DESCRIPTION
I got the following error when compiling with recent versions of GHC (9.2.8 and 9.6.2):

```
Error: cabal: Could not resolve dependencies:
[__0] trying: hpdft-0.1.1.1 (user goal)
[__1] trying: regex-compat-tdfa-0.95.1.4 (dependency of hpdft)
[__2] next goal: base (dependency of hpdft)
[__2] rejecting: base-4.16.4.0/installed-4.16.4.0 (conflict: regex-compat-tdfa
+/-newbase +/-splitbase => base<4.15)
```

This PR fix this problem.
